### PR TITLE
Dependency List for Android 8 and set Context

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,12 @@ android {
 
 dependencies {
     compile "com.facebook.react:react-native:+"
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:appcompat-v7:23.2.1'
     compile 'ai.api:sdk:2.0.7@aar'
-    compile 'ai.api:libai:1.4.8'
     compile 'com.google.code.gson:gson:2.3'
+    compile 'commons-io:commons-io:2.4'
+    compile('ai.api:libai:1.4.8') {
+       exclude module: 'log4j-core'
+    }
 }

--- a/android/src/main/java/de/innfactory/apiai/RNApiAiModule.java
+++ b/android/src/main/java/de/innfactory/apiai/RNApiAiModule.java
@@ -101,14 +101,14 @@ public class RNApiAiModule extends ReactContextBaseJavaModule implements AIListe
     @ReactMethod
     public void setContextsAsJson(String contextsAsJson) {
         Gson gson = new Gson();
-        contexts = gson.fromJson(contextsAsJson, new TypeToken<List<Entity>>() {
+        contexts = gson.fromJson(contextsAsJson, new TypeToken<List<AIContext>>() {
         }.getType());
     }
 
     @ReactMethod
     public void setPermanentContextsAsJson(String contextsAsJson) {
         Gson gson = new Gson();
-        permantentContexts = gson.fromJson(contextsAsJson, new TypeToken<List<Entity>>() {
+        permantentContexts = gson.fromJson(contextsAsJson, new TypeToken<List<AIContext>>() {
         }.getType());
     }
 


### PR DESCRIPTION
 - Android 8 is not able to find the api.ai classes. Explicitly  adding api.ai dependencies to the project 
 
 - Set context function was instanciating the context object using `Entity` instead of `AIContext`