### PR TITLE
Request Query with token

### DIFF
--- a/js/Dialogflow_V2.js
+++ b/js/Dialogflow_V2.js
@@ -134,7 +134,40 @@ export class Dialogflow_V2 {
             })
             .catch(onError);
     };
+    
+    requestQueryWithAuth = async (query, token, onResult, onError) => {
 
+        const data = {
+            "queryParams": {
+                "contexts": this.mergeContexts(this.contexts, this.permanentContexts),
+                "sessionEntityTypes": []
+            },
+            "queryInput": {
+                "text": {
+                    "text": query,
+                    "languageCode": this.languageTag,
+                },
+            },
+            token
+        }
+
+        this.contexts = null;
+        this.entities = null;
+
+        fetch(DEFAULT_BASE_URL + this.projectId + "/agent/sessions/" + this.sessionId + ":detectIntent", {
+            method: "POST",
+            headers: {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Authorization': 'Bearer ' + this.accessToken,
+                'charset': "utf-8"
+            },
+            body: JSON.stringify(data)
+        })
+            .then(function (response) {
+                var json = response.json().then(onResult)
+            })
+            .catch(onError);
+    };
 
     mergeContexts(context1, context2) {
         if (!context1) {


### PR DESCRIPTION
#### Description
When a user want to make request to Dialogflow which would be used for fulfilment via web hook to a secure external API then its required to append the token to every query query object so that its accessible in fulfilment   
